### PR TITLE
Fix: react/no-unescaped-entities

### DIFF
--- a/frontend/src/components/Layouts/Navbar/Navbar.tsx
+++ b/frontend/src/components/Layouts/Navbar/Navbar.tsx
@@ -47,7 +47,7 @@ export default function Navbar() {
             QUIÉNES SOMOS
           </Link>
           <Link href="/Faq" className="hover:text-gray-400">
-            FAQ'S
+            FAQ&apos;S {/* Comillas escapadas */}
           </Link>
         </div>
       </div>
@@ -85,7 +85,7 @@ export default function Navbar() {
               className="hover:text-gray-400"
               onClick={closeMenu}
             >
-              FAQ's
+              FAQ&apos;S {/* Comillas escapadas */}
             </Link>
             <div className="">
               <p className="text-sm font-normal font-['Poppins'] leading-snug mt-9 mb-5">


### PR DESCRIPTION
Se reemplazaron las comillas simples en "FAQ's" por `&apos;` en el archivo `Navbar.tsx` para evitar errores de compilación relacionados con entidades no escapadas.
Gracias por nada vercel.